### PR TITLE
Fixes item param using wrong type

### DIFF
--- a/app/src/main/java/com/hannesdorfmann/adapterdelegates/sample/adapterdelegates/SnakeListItemAdapterDelegate.java
+++ b/app/src/main/java/com/hannesdorfmann/adapterdelegates/sample/adapterdelegates/SnakeListItemAdapterDelegate.java
@@ -27,8 +27,7 @@ public class SnakeListItemAdapterDelegate extends
   }
 
   @Override
-  protected boolean isForViewType(@NonNull DisplayableItem item, List<DisplayableItem> items,
-      int position) {
+  protected boolean isForViewType(@NonNull Snake item, List<DisplayableItem> items, int position) {
     return item instanceof Snake;
   }
 

--- a/library/src/main/java/com/hannesdorfmann/adapterdelegates/AbsListItemAdapterDelegate.java
+++ b/library/src/main/java/com/hannesdorfmann/adapterdelegates/AbsListItemAdapterDelegate.java
@@ -18,7 +18,7 @@ import java.util.List;
  * class CatAdapterDelegate extends AbsListItemAdapterDelegate<Cat, Animal, CatViewHolder>{
  *
  *    @Override
- *    protected boolean isForViewType(Animal item, List<Animal> items, position){
+ *    protected boolean isForViewType(Cat item, List<Animal> items, position){
  *      return item instanceof Cat;
  *    }
  *
@@ -51,7 +51,7 @@ public abstract class AbsListItemAdapterDelegate<I extends T, T, VH extends Recy
   }
 
   @Override public final boolean isForViewType(@NonNull List<T> items, int position) {
-    return isForViewType(items.get(position), items, position);
+    return isForViewType((I) items.get(position), items, position);
   }
 
   @Override public final void onBindViewHolder(@NonNull List<T> items, int position,
@@ -67,7 +67,7 @@ public abstract class AbsListItemAdapterDelegate<I extends T, T, VH extends Recy
    * @param position The items position in the dataset (list)
    * @return true if this AdapterDelegate is responsible for that, otherwise false
    */
-  protected abstract boolean isForViewType(@NonNull T item, List<T> items, int position);
+  protected abstract boolean isForViewType(@NonNull I item, List<T> items, int position);
 
   /**
    * Creates the  {@link RecyclerView.ViewHolder} for the given data source item

--- a/library/src/main/java/com/hannesdorfmann/adapterdelegates/AbsListItemAdapterDelegate.java
+++ b/library/src/main/java/com/hannesdorfmann/adapterdelegates/AbsListItemAdapterDelegate.java
@@ -3,6 +3,7 @@ package com.hannesdorfmann.adapterdelegates;
 import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
 import android.view.ViewGroup;
+
 import java.util.List;
 
 /**
@@ -51,7 +52,11 @@ public abstract class AbsListItemAdapterDelegate<I extends T, T, VH extends Recy
   }
 
   @Override public final boolean isForViewType(@NonNull List<T> items, int position) {
-    return isForViewType((I) items.get(position), items, position);
+    try {
+      return isForViewType((I) items.get(position), items, position);
+    } catch (ClassCastException e) {
+      return false;
+    }
   }
 
   @Override public final void onBindViewHolder(@NonNull List<T> items, int position,

--- a/library/src/test/java/com/hannesdorfmann/adapterdelegates/AbsListItemAdapterDelegateTest.java
+++ b/library/src/test/java/com/hannesdorfmann/adapterdelegates/AbsListItemAdapterDelegateTest.java
@@ -4,11 +4,14 @@ import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.view.ViewGroup;
-import java.util.ArrayList;
-import java.util.List;
+
 import junit.framework.Assert;
+
 import org.junit.Test;
 import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Hannes Dorfmann
@@ -56,7 +59,7 @@ public class AbsListItemAdapterDelegateTest {
     }
 
     @Override
-    protected boolean isForViewType(@NonNull Animal item, List<Animal> items, int position) {
+    protected boolean isForViewType(@NonNull Cat item, List<Animal> items, int position) {
       isForViewTypeCalled = true;
       return false;
     }


### PR DESCRIPTION
According to the `AbsListItemAdapterDelegate` example in the README the item param in the method `isForViewType` should use the subtype of `T` of the first param in the class constructor