### PR TITLE
Any reasons not to pass view type to delegates?

### DIFF
--- a/library/src/main/java/com/hannesdorfmann/adapterdelegates2/AdapterDelegatesManager.java
+++ b/library/src/main/java/com/hannesdorfmann/adapterdelegates2/AdapterDelegatesManager.java
@@ -242,7 +242,7 @@ public class AdapterDelegatesManager<T> {
       }
     }
 
-    RecyclerView.ViewHolder vh = delegate.onCreateViewHolder(parent);
+    RecyclerView.ViewHolder vh = delegate.onCreateViewHolder(parent, viewType);
     if (vh == null) {
       throw new NullPointerException("ViewHolder returned from AdapterDelegate "
           + delegate


### PR DESCRIPTION
Hello,

it looks like delegate can handle multiple view types, but without this change it can only handle one view holder (or one inheritance hierarchy of view holders). 

In our application we would like to reuse groups of view types usually accompanying each other. E.x. list elements & header row. 

Any reasons why did you decide not to pass view type to adapter delegate?

Thanks