### PR TITLE
Annotate items with @NonNull

### DIFF
--- a/library/src/main/java/com/hannesdorfmann/adapterdelegates2/AbsListItemAdapterDelegate.java
+++ b/library/src/main/java/com/hannesdorfmann/adapterdelegates2/AbsListItemAdapterDelegate.java
@@ -63,7 +63,7 @@ public abstract class AbsListItemAdapterDelegate<I extends T, T, VH extends Recy
    * @param position The items position in the dataset (list)
    * @return true if this AdapterDelegate is responsible for that, otherwise false
    */
-  protected abstract boolean isForViewType(@NonNull T item, List<T> items, int position);
+  protected abstract boolean isForViewType(@NonNull T item, @NonNull List<T> items, int position);
 
   /**
    * Creates the  {@link RecyclerView.ViewHolder} for the given data source item


### PR DESCRIPTION
The `isForViewType(@NonNull T, List<T>, int)` is only called by `isForViewType(@NonNull List<T>, int)`. As the first parameter from the latter method is passed into the second argument of the former method without mutation, it's state of being non null remains unchanged.