### PR TITLE
Update getItemViewType to throw correct exception

### DIFF
--- a/library/src/main/java/com/hannesdorfmann/adapterdelegates3/AdapterDelegatesManager.java
+++ b/library/src/main/java/com/hannesdorfmann/adapterdelegates3/AdapterDelegatesManager.java
@@ -227,7 +227,7 @@ public class AdapterDelegatesManager<T> {
       return FALLBACK_DELEGATE_VIEW_TYPE;
     }
 
-    throw new NullPointerException(
+    throw new IllegalArgumentException(
         "No AdapterDelegate added that matches position=" + position + " in data source");
   }
 


### PR DESCRIPTION
getItemViewType states that it will throw an IllegalArgumentException if no delegate is found but it actually throws a NullPointerException