### PR TITLE
added support for headers to AdapterDelegatesManager

### DIFF
--- a/library/src/main/java/com/hannesdorfmann/adapterdelegates3/AbsHeaderAdapterDelegate.java
+++ b/library/src/main/java/com/hannesdorfmann/adapterdelegates3/AbsHeaderAdapterDelegate.java
@@ -1,0 +1,49 @@
+package com.hannesdorfmann.adapterdelegates3;
+
+import android.support.annotation.NonNull;
+import android.support.v7.widget.RecyclerView;
+import android.view.ViewGroup;
+
+import java.util.List;
+
+public abstract class AbsHeaderAdapterDelegate<VH extends RecyclerView.ViewHolder>
+		extends AdapterDelegate {
+
+	@Override
+	protected boolean isForViewType(@NonNull Object items, int position) {
+		return isForViewType(position);
+	}
+
+	@Override
+	protected void onBindViewHolder(@NonNull Object items, int position, @NonNull RecyclerView.ViewHolder holder, @NonNull List payloads) {
+		onBindViewHolder((VH) holder);
+	}
+
+	/**
+	 * Called to determine whether this AdapterDelegate is the responsible for the given item in the
+	 * list or not
+	 * element
+	 *
+	 * @param position The items position in the dataset (list)
+	 * @return true if this AdapterDelegate is responsible for that, otherwise false
+	 */
+	protected abstract boolean isForViewType(int position);
+
+	/**
+	 * Creates the  {@link RecyclerView.ViewHolder} for the given data source item
+	 *
+	 * @param parent The ViewGroup parent of the given datasource
+	 * @return ViewHolder
+	 */
+	@NonNull
+	@Override
+	protected abstract VH onCreateViewHolder(@NonNull ViewGroup parent);
+
+	/**
+	 * Called to bind the {@link RecyclerView.ViewHolder} to the item of the dataset
+	 *
+	 * @param viewHolder The ViewHolder
+	 */
+	protected abstract void onBindViewHolder(@NonNull VH viewHolder);
+
+}

--- a/library/src/main/java/com/hannesdorfmann/adapterdelegates3/AdapterDelegatesManager.java
+++ b/library/src/main/java/com/hannesdorfmann/adapterdelegates3/AdapterDelegatesManager.java
@@ -72,6 +72,20 @@ public class AdapterDelegatesManager<T> {
   protected SparseArrayCompat<AdapterDelegate<T>> delegates = new SparseArrayCompat();
   protected AdapterDelegate<T> fallbackDelegate;
 
+	private boolean hasHeader;
+
+	/**
+	 * Adds an {@link AdapterDelegate} with the specified view type as a header
+	 *
+	 * @param delegate the delegate to add
+	 * @return self
+	 * @see #addDelegate(AdapterDelegate)
+	 */
+	public AdapterDelegatesManager<T> addHeader(@NonNull AdapterDelegate delegate) {
+		hasHeader = true;
+		return addDelegate(delegate);
+	}
+
   /**
    * Adds an {@link AdapterDelegate}.
    * <b>This method automatically assign internally the view type integer by using the next
@@ -211,24 +225,25 @@ public class AdapterDelegatesManager<T> {
    */
   public int getItemViewType(@NonNull T items, int position) {
 
-    if (items == null) {
-      throw new NullPointerException("Items datasource is null!");
-    }
+	  if (items == null) {
+		  throw new NullPointerException("Items datasource is null!");
+	  }
 
-    int delegatesCount = delegates.size();
-    for (int i = 0; i < delegatesCount; i++) {
-      AdapterDelegate<T> delegate = delegates.valueAt(i);
-      if (delegate.isForViewType(items, position)) {
-        return delegates.keyAt(i);
-      }
-    }
+	  int delegatesCount = delegates.size();
+	  for (int i = 0; i < delegatesCount; i++) {
+		  AdapterDelegate<T> delegate = delegates.valueAt(i);
+		  // decrease position when header is present
+		  if (delegate.isForViewType(items, hasHeader ? position - 1 : position)) {
+			  return delegates.keyAt(i);
+		  }
+	  }
 
-    if (fallbackDelegate != null) {
-      return FALLBACK_DELEGATE_VIEW_TYPE;
-    }
+	  if (fallbackDelegate != null) {
+		  return FALLBACK_DELEGATE_VIEW_TYPE;
+	  }
 
-    throw new NullPointerException(
-        "No AdapterDelegate added that matches position=" + position + " in data source");
+	  throw new NullPointerException(
+			  "No AdapterDelegate added that matches position=" + position + " in data source");
   }
 
   /**
@@ -278,7 +293,7 @@ public class AdapterDelegatesManager<T> {
           + " for viewType = "
           + viewHolder.getItemViewType());
     }
-    delegate.onBindViewHolder(items, position, viewHolder, payloads);
+	  delegate.onBindViewHolder(items, hasHeader ? position - 1 : position, viewHolder, payloads);
   }
 
   /**
@@ -438,4 +453,14 @@ public class AdapterDelegatesManager<T> {
   @Nullable public AdapterDelegate<T> getFallbackDelegate() {
     return fallbackDelegate;
   }
+
+	/**
+	 * Get the amount of items in the list
+	 *
+	 * @param itemsCount the amount of items in the list
+	 * @return the amount of items in the list, +1 if header is shown
+	 */
+	public int getItemCount(int itemsCount) {
+		return hasHeader ? itemsCount + 1 : itemsCount;
+	}
 }

--- a/library/src/test/java/com/hannesdorfmann/adapterdelegates3/AbsHeaderAdapterDelegateTest.java
+++ b/library/src/test/java/com/hannesdorfmann/adapterdelegates3/AbsHeaderAdapterDelegateTest.java
@@ -1,0 +1,88 @@
+package com.hannesdorfmann.adapterdelegates3;
+
+import android.support.annotation.NonNull;
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+import android.view.ViewGroup;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Thomas Richtsfeld
+ */
+public class AbsHeaderAdapterDelegateTest {
+
+	@Test
+	public void invokeMethods() {
+
+		List<Animal> items = new ArrayList<>();
+		items.add(new Cat());
+
+		CatAbsListItemAdapterDelegate delegate = new CatAbsListItemAdapterDelegate();
+
+		delegate.isForViewType(items, 0);
+		Assert.assertTrue(delegate.isForViewTypeCalled);
+
+		ViewGroup parent = Mockito.mock(ViewGroup.class);
+		CatViewHolder vh = delegate.onCreateViewHolder(parent);
+		Assert.assertTrue(delegate.onCreateViewHolderCalled);
+
+		delegate.onBindViewHolder(items, 0, vh, new ArrayList<Object>());
+		Assert.assertTrue(delegate.onBindViewHolderCalled);
+
+	}
+
+	interface Animal {
+
+	}
+
+	class Cat implements Animal {
+
+	}
+
+	class CatViewHolder extends RecyclerView.ViewHolder {
+
+		public CatViewHolder(View itemView) {
+			super(itemView);
+		}
+	}
+
+	class CatAbsListItemAdapterDelegate
+			extends AbsHeaderAdapterDelegate<CatViewHolder> {
+
+		public boolean isForViewTypeCalled = false;
+		public boolean onCreateViewHolderCalled = false;
+		public boolean onBindViewHolderCalled = false;
+		public boolean onViewDetachedFromWindow = false;
+
+		@Override
+		protected boolean isForViewType(int position) {
+			isForViewTypeCalled = true;
+			return false;
+		}
+
+		@NonNull
+		@Override
+		public CatViewHolder onCreateViewHolder(@NonNull ViewGroup parent) {
+			onCreateViewHolderCalled = true;
+			return new CatViewHolder(Mockito.mock(View.class));
+		}
+
+		@Override
+		protected void onBindViewHolder(@NonNull CatViewHolder viewHolder) {
+			onBindViewHolderCalled = true;
+		}
+
+		@Override
+		public void onViewDetachedFromWindow(RecyclerView.ViewHolder holder) {
+			super.onViewDetachedFromWindow(holder);
+			onViewDetachedFromWindow = true;
+		}
+	}
+}


### PR DESCRIPTION
To support headers for 'RecyclerView' I added the ability to add headers into the `AdapterDelegatesManager`. Before it was only possible to use a header with adding it to the items data source.