### PR TITLE
Annotate parent with @NonNull

### DIFF
--- a/app/src/main/java/com/hannesdorfmann/adapterdelegates3/sample/adapterdelegates/AdvertisementAdapterDelegate.java
+++ b/app/src/main/java/com/hannesdorfmann/adapterdelegates3/sample/adapterdelegates/AdvertisementAdapterDelegate.java
@@ -44,7 +44,7 @@ public class AdvertisementAdapterDelegate extends AdapterDelegate<List<Displayab
     return items.get(position) instanceof Advertisement;
   }
 
-  @NonNull @Override public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup parent) {
+  @NonNull @Override public RecyclerView.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent) {
     return new AdvertisementViewHolder(inflater.inflate(R.layout.item_advertisement, parent, false));
   }
 

--- a/app/src/main/java/com/hannesdorfmann/adapterdelegates3/sample/adapterdelegates/CatAdapterDelegate.java
+++ b/app/src/main/java/com/hannesdorfmann/adapterdelegates3/sample/adapterdelegates/CatAdapterDelegate.java
@@ -46,7 +46,7 @@ public class CatAdapterDelegate extends AdapterDelegate<List<DisplayableItem>> {
     return items.get(position) instanceof Cat;
   }
 
-  @NonNull @Override public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup parent) {
+  @NonNull @Override public RecyclerView.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent) {
     Log.d("Scroll", "CatAdapterDelegate createViewHolder ");
     return new CatViewHolder(inflater.inflate(R.layout.item_cat, parent, false));
   }

--- a/app/src/main/java/com/hannesdorfmann/adapterdelegates3/sample/adapterdelegates/DogAdapterDelegate.java
+++ b/app/src/main/java/com/hannesdorfmann/adapterdelegates3/sample/adapterdelegates/DogAdapterDelegate.java
@@ -46,7 +46,7 @@ public class DogAdapterDelegate extends AdapterDelegate<List<DisplayableItem>> {
     return items.get(position) instanceof Dog;
   }
 
-  @NonNull @Override public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup parent) {
+  @NonNull @Override public RecyclerView.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent) {
 
     Log.d("Scroll", "DogAdapterDelegate create");
     return new DogViewHolder(inflater.inflate(R.layout.item_dog, parent, false));

--- a/app/src/main/java/com/hannesdorfmann/adapterdelegates3/sample/adapterdelegates/GeckoAdapterDelegate.java
+++ b/app/src/main/java/com/hannesdorfmann/adapterdelegates3/sample/adapterdelegates/GeckoAdapterDelegate.java
@@ -46,7 +46,7 @@ public class GeckoAdapterDelegate extends AdapterDelegate<List<DisplayableItem>>
     return items.get(position) instanceof Gecko;
   }
 
-  @NonNull @Override public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup parent) {
+  @NonNull @Override public RecyclerView.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent) {
 
     Log.d("Scroll", "GeckoAdapterDelegate create");
     return new GeckoViewHolder(inflater.inflate(R.layout.item_gecko, parent, false));

--- a/app/src/main/java/com/hannesdorfmann/adapterdelegates3/sample/adapterdelegates/ReptilesFallbackDelegate.java
+++ b/app/src/main/java/com/hannesdorfmann/adapterdelegates3/sample/adapterdelegates/ReptilesFallbackDelegate.java
@@ -23,7 +23,7 @@ public class ReptilesFallbackDelegate extends AbsFallbackAdapterDelegate<List<Di
     inflater = activity.getLayoutInflater();
   }
 
-  @NonNull @Override public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup parent) {
+  @NonNull @Override public RecyclerView.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent) {
     View view = inflater.inflate(R.layout.item_unknown_reptile, parent, false);
     return new ReptileFallbackViewHolder(view);
   }

--- a/library/src/main/java/com/hannesdorfmann/adapterdelegates3/AdapterDelegate.java
+++ b/library/src/main/java/com/hannesdorfmann/adapterdelegates3/AdapterDelegate.java
@@ -49,7 +49,7 @@ public abstract class AdapterDelegate<T> {
    * @param parent The ViewGroup parent of the given datasource
    * @return The new instantiated {@link RecyclerView.ViewHolder}
    */
-  @NonNull abstract protected RecyclerView.ViewHolder onCreateViewHolder(ViewGroup parent);
+  @NonNull abstract protected RecyclerView.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent);
 
   /**
    * Called to bind the {@link RecyclerView.ViewHolder} to the item of the datas source set

--- a/library/src/test/java/com/hannesdorfmann/adapterdelegates3/AdapterDelegatesManagerTest.java
+++ b/library/src/test/java/com/hannesdorfmann/adapterdelegates3/AdapterDelegatesManagerTest.java
@@ -22,7 +22,7 @@ public class AdapterDelegatesManagerTest {
         return false;
       }
 
-      @Override public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup parent) {
+      @Override public RecyclerView.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent) {
         return null;
       }
 
@@ -37,7 +37,7 @@ public class AdapterDelegatesManagerTest {
         return false;
       }
 
-      @Override public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup parent) {
+      @Override public RecyclerView.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent) {
         return null;
       }
 

--- a/library/src/test/java/com/hannesdorfmann/adapterdelegates3/SpyableAdapterDelegate.java
+++ b/library/src/test/java/com/hannesdorfmann/adapterdelegates3/SpyableAdapterDelegate.java
@@ -61,7 +61,7 @@ public class SpyableAdapterDelegate<T> extends AdapterDelegate<T> {
     return isForThat;
   }
 
-  @Override public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup parent) {
+  @Override public RecyclerView.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent) {
 
     onCreateViewHolderCalled = true;
     return viewHolder;


### PR DESCRIPTION
`parent` should never be `null`. Such a deduction had similarly been made by the overridden method `onCreateViewHolder(…)` in [AbsListItemAdapterDelegate](https://github.com/sockeqwe/AdapterDelegates/blob/07da6488c089ec10af164d842e27bdfe2df246f2/library/src/main/java/com/hannesdorfmann/adapterdelegates3/AbsListItemAdapterDelegate.java#L70).