### PR TITLE
Make naming of ViewHolder parameters consistent

### DIFF
--- a/app/src/main/java/com/hannesdorfmann/adapterdelegates3/sample/animations/ItemAdapterDelegate.java
+++ b/app/src/main/java/com/hannesdorfmann/adapterdelegates3/sample/animations/ItemAdapterDelegate.java
@@ -33,13 +33,13 @@ public class ItemAdapterDelegate
     return new ItemViewHolder(inflater.inflate(R.layout.item_animation, parent, false));
   }
 
-  @Override protected void onBindViewHolder(@NonNull Item item, @NonNull ItemViewHolder viewHolder,
+  @Override protected void onBindViewHolder(@NonNull Item item, @NonNull ItemViewHolder holder,
       @NonNull List<Object> payloads) {
 
     Log.d("ItemAdapterDelegate", "Change Payload: " + payloads);
 
-    viewHolder.textView.setText(item.text);
-    viewHolder.textView.setBackgroundColor(item.color);
+    holder.textView.setText(item.text);
+    holder.textView.setBackgroundColor(item.color);
   }
 
   class ItemViewHolder extends RecyclerView.ViewHolder {

--- a/library/src/main/java/com/hannesdorfmann/adapterdelegates3/AbsListItemAdapterDelegate.java
+++ b/library/src/main/java/com/hannesdorfmann/adapterdelegates3/AbsListItemAdapterDelegate.java
@@ -27,8 +27,8 @@ import java.util.List;
  * @Override public CatViewHolder onCreateViewHolder(ViewGroup parent){
  * return new CatViewHolder(inflater.inflate(R.layout.item_cat, parent, false));
  * }
- * @Override protected void onBindViewHolder(Cat item, CatViewHolder viewHolder);
- * viewHolder.setName(cat.getName());
+ * @Override protected void onBindViewHolder(Cat item, CatViewHolder holder);
+ * holder.setName(cat.getName());
  * ...
  * }
  * }
@@ -73,9 +73,9 @@ public abstract class AbsListItemAdapterDelegate<I extends T, T, VH extends Recy
    * Called to bind the {@link RecyclerView.ViewHolder} to the item of the dataset
    *
    * @param item The data item
-   * @param viewHolder The ViewHolder
+   * @param holder The ViewHolder
    * @param payloads The payloads
    */
-  protected abstract void onBindViewHolder(@NonNull I item, @NonNull VH viewHolder,
+  protected abstract void onBindViewHolder(@NonNull I item, @NonNull VH holder,
       @NonNull List<Object> payloads);
 }

--- a/library/src/main/java/com/hannesdorfmann/adapterdelegates3/AdapterDelegate.java
+++ b/library/src/main/java/com/hannesdorfmann/adapterdelegates3/AdapterDelegate.java
@@ -78,9 +78,9 @@ public abstract class AdapterDelegate<T> {
    * get
    * its adapter position.
    *
-   * @param viewHolder The ViewHolder for the view being recycled
+   * @param holder The ViewHolder for the view being recycled
    */
-  protected void onViewRecycled(@NonNull RecyclerView.ViewHolder viewHolder) {
+  protected void onViewRecycled(@NonNull RecyclerView.ViewHolder holder) {
   }
 
   /**

--- a/library/src/main/java/com/hannesdorfmann/adapterdelegates3/AdapterDelegatesManager.java
+++ b/library/src/main/java/com/hannesdorfmann/adapterdelegates3/AdapterDelegatesManager.java
@@ -263,22 +263,22 @@ public class AdapterDelegatesManager<T> {
    *
    * @param items Adapter's data source
    * @param position the position in data source
-   * @param viewHolder the ViewHolder to bind
+   * @param holder the ViewHolder to bind
    * @param payloads A non-null list of merged payloads. Can be empty list if requires full update.
    * @throws NullPointerException if no AdapterDelegate has been registered for ViewHolders
    * viewType
    */
   public void onBindViewHolder(@NonNull T items, int position,
-      @NonNull RecyclerView.ViewHolder viewHolder, List payloads) {
+      @NonNull RecyclerView.ViewHolder holder, List payloads) {
 
-    AdapterDelegate<T> delegate = getDelegateForViewType(viewHolder.getItemViewType());
+    AdapterDelegate<T> delegate = getDelegateForViewType(holder.getItemViewType());
     if (delegate == null) {
       throw new NullPointerException("No delegate found for item at position = "
           + position
           + " for viewType = "
-          + viewHolder.getItemViewType());
+          + holder.getItemViewType());
     }
-    delegate.onBindViewHolder(items, position, viewHolder,
+    delegate.onBindViewHolder(items, position, holder,
         payloads != null ? payloads : PAYLOADS_EMPTY_LIST);
   }
 
@@ -288,37 +288,37 @@ public class AdapterDelegatesManager<T> {
    *
    * @param items Adapter's data source
    * @param position the position in data source
-   * @param viewHolder the ViewHolder to bind
+   * @param holder the ViewHolder to bind
    * @throws NullPointerException if no AdapterDelegate has been registered for ViewHolders
    * viewType
    */
   public void onBindViewHolder(@NonNull T items, int position,
-      @NonNull RecyclerView.ViewHolder viewHolder) {
-    onBindViewHolder(items, position, viewHolder, PAYLOADS_EMPTY_LIST);
+      @NonNull RecyclerView.ViewHolder holder) {
+    onBindViewHolder(items, position, holder, PAYLOADS_EMPTY_LIST);
   }
 
   /**
    * Must be called from {@link RecyclerView.Adapter#onViewRecycled(RecyclerView.ViewHolder)}
    *
-   * @param viewHolder The ViewHolder for the view being recycled
+   * @param holder The ViewHolder for the view being recycled
    */
-  public void onViewRecycled(@NonNull RecyclerView.ViewHolder viewHolder) {
-    AdapterDelegate<T> delegate = getDelegateForViewType(viewHolder.getItemViewType());
+  public void onViewRecycled(@NonNull RecyclerView.ViewHolder holder) {
+    AdapterDelegate<T> delegate = getDelegateForViewType(holder.getItemViewType());
     if (delegate == null) {
       throw new NullPointerException("No delegate found for "
-          + viewHolder
+          + holder
           + " for item at position = "
-          + viewHolder.getAdapterPosition()
+          + holder.getAdapterPosition()
           + " for viewType = "
-          + viewHolder.getItemViewType());
+          + holder.getItemViewType());
     }
-    delegate.onViewRecycled(viewHolder);
+    delegate.onViewRecycled(holder);
   }
 
   /**
    * Must be called from {@link RecyclerView.Adapter#onFailedToRecycleView(RecyclerView.ViewHolder)}
    *
-   * @param viewHolder The ViewHolder containing the View that could not be recycled due to its
+   * @param holder The ViewHolder containing the View that could not be recycled due to its
    * transient state.
    * @return True if the View should be recycled, false otherwise. Note that if this method
    * returns <code>true</code>, RecyclerView <em>will ignore</em> the transient state of
@@ -326,53 +326,53 @@ public class AdapterDelegatesManager<T> {
    * RecyclerView will check the View's transient state again before giving a final decision.
    * Default implementation returns false.
    */
-  public boolean onFailedToRecycleView(@NonNull RecyclerView.ViewHolder viewHolder) {
-    AdapterDelegate<T> delegate = getDelegateForViewType(viewHolder.getItemViewType());
+  public boolean onFailedToRecycleView(@NonNull RecyclerView.ViewHolder holder) {
+    AdapterDelegate<T> delegate = getDelegateForViewType(holder.getItemViewType());
     if (delegate == null) {
       throw new NullPointerException("No delegate found for "
-          + viewHolder
+          + holder
           + " for item at position = "
-          + viewHolder.getAdapterPosition()
+          + holder.getAdapterPosition()
           + " for viewType = "
-          + viewHolder.getItemViewType());
+          + holder.getItemViewType());
     }
-    return delegate.onFailedToRecycleView(viewHolder);
+    return delegate.onFailedToRecycleView(holder);
   }
 
   /**
    * Must be called from {@link RecyclerView.Adapter#onViewAttachedToWindow(RecyclerView.ViewHolder)}
    *
-   * @param viewHolder Holder of the view being attached
+   * @param holder Holder of the view being attached
    */
-  public void onViewAttachedToWindow(RecyclerView.ViewHolder viewHolder) {
-    AdapterDelegate<T> delegate = getDelegateForViewType(viewHolder.getItemViewType());
+  public void onViewAttachedToWindow(RecyclerView.ViewHolder holder) {
+    AdapterDelegate<T> delegate = getDelegateForViewType(holder.getItemViewType());
     if (delegate == null) {
       throw new NullPointerException("No delegate found for "
-          + viewHolder
+          + holder
           + " for item at position = "
-          + viewHolder.getAdapterPosition()
+          + holder.getAdapterPosition()
           + " for viewType = "
-          + viewHolder.getItemViewType());
+          + holder.getItemViewType());
     }
-    delegate.onViewAttachedToWindow(viewHolder);
+    delegate.onViewAttachedToWindow(holder);
   }
 
   /**
    * Must be called from {@link RecyclerView.Adapter#onViewDetachedFromWindow(RecyclerView.ViewHolder)}
    *
-   * @param viewHolder Holder of the view being attached
+   * @param holder Holder of the view being attached
    */
-  public void onViewDetachedFromWindow(RecyclerView.ViewHolder viewHolder) {
-    AdapterDelegate<T> delegate = getDelegateForViewType(viewHolder.getItemViewType());
+  public void onViewDetachedFromWindow(RecyclerView.ViewHolder holder) {
+    AdapterDelegate<T> delegate = getDelegateForViewType(holder.getItemViewType());
     if (delegate == null) {
       throw new NullPointerException("No delegate found for "
-          + viewHolder
+          + holder
           + " for item at position = "
-          + viewHolder.getAdapterPosition()
+          + holder.getAdapterPosition()
           + " for viewType = "
-          + viewHolder.getItemViewType());
+          + holder.getItemViewType());
     }
-    delegate.onViewDetachedFromWindow(viewHolder);
+    delegate.onViewDetachedFromWindow(holder);
   }
 
   /**

--- a/library/src/test/java/com/hannesdorfmann/adapterdelegates3/AbsListItemAdapterDelegateTest.java
+++ b/library/src/test/java/com/hannesdorfmann/adapterdelegates3/AbsListItemAdapterDelegateTest.java
@@ -67,7 +67,7 @@ public class AbsListItemAdapterDelegateTest {
     }
 
     @Override
-    protected void onBindViewHolder(@NonNull Cat item, @NonNull CatViewHolder viewHolder, List payloads) {
+    protected void onBindViewHolder(@NonNull Cat item, @NonNull CatViewHolder holder, List payloads) {
       onBindViewHolderCalled = true;
     }
 

--- a/library/src/test/java/com/hannesdorfmann/adapterdelegates3/SpyableAdapterDelegate.java
+++ b/library/src/test/java/com/hannesdorfmann/adapterdelegates3/SpyableAdapterDelegate.java
@@ -83,8 +83,8 @@ public class SpyableAdapterDelegate<T> extends AdapterDelegate<T> {
     onViewAtachedToWindowCalled = true;
   }
 
-  @Override public void onViewRecycled(@NonNull RecyclerView.ViewHolder viewHolder) {
-    super.onViewRecycled(viewHolder);
+  @Override public void onViewRecycled(@NonNull RecyclerView.ViewHolder holder) {
+    super.onViewRecycled(holder);
     onViewRecycledCalled = true;
   }
 


### PR DESCRIPTION
Use `holder` everywhere instead of `viewHolder` in some places and `holder` in the others. I chose `holder` because that's what RecyclerView.Adapter uses.