### PR TITLE
Improve error message in AdapterDelegatesManager when no AdapterDelegate is found.

### DIFF
--- a/library/src/main/java/com/hannesdorfmann/adapterdelegates4/AdapterDelegatesManager.java
+++ b/library/src/main/java/com/hannesdorfmann/adapterdelegates4/AdapterDelegatesManager.java
@@ -244,16 +244,16 @@ public class AdapterDelegatesManager<T> {
             return FALLBACK_DELEGATE_VIEW_TYPE;
         }
 
+        final String errorMessage;
 
-        final String itemString;
         if (items instanceof List<?>) {
-            itemString = ((List<?>) items).get(position).toString();
-        } else {
-            itemString = items.toString();
+            String itemString = ((List<?>) items).get(position).toString();
+            errorMessage = "No AdapterDelegate added that matches item=" + itemString + " at position=" + position + " in data source";
+        }  else {
+            errorMessage = "No AdapterDelegate added for item at position=" + position + ". items=" + items;
         }
 
-        throw new NullPointerException(
-                "No AdapterDelegate added that matches item=" + itemString + " at position=" + position + " in data source");
+        throw new NullPointerException(errorMessage);
     }
 
     /**

--- a/library/src/main/java/com/hannesdorfmann/adapterdelegates4/AdapterDelegatesManager.java
+++ b/library/src/main/java/com/hannesdorfmann/adapterdelegates4/AdapterDelegatesManager.java
@@ -244,8 +244,16 @@ public class AdapterDelegatesManager<T> {
             return FALLBACK_DELEGATE_VIEW_TYPE;
         }
 
+
+        final String itemString;
+        if (items instanceof List<?>) {
+            itemString = ((List<?>) items).get(position).toString();
+        } else {
+            itemString = items.toString();
+        }
+
         throw new NullPointerException(
-                "No AdapterDelegate added that matches position=" + position + " in data source");
+                "No AdapterDelegate added that matches item=" + itemString + " at position=" + position + " in data source");
     }
 
     /**


### PR DESCRIPTION
Motivation: Just the position, does not tell me what is wrong since I don't know the underlying data set. From the particular item I can reason why things are faulty.

Can be tested out by applying the git diff:

```diff
diff --git a/app/src/main/java/com/hannesdorfmann/adapterdelegates4/sample/MainListAdapter.kt b/app/src/main/java/com/hannesdorfmann/adapterdelegates4/sample/MainListAdapter.kt
index 730aeb5..b47d313 100644
--- a/app/src/main/java/com/hannesdorfmann/adapterdelegates4/sample/MainListAdapter.kt
+++ b/app/src/main/java/com/hannesdorfmann/adapterdelegates4/sample/MainListAdapter.kt
@@ -12,7 +12,7 @@ import com.hannesdorfmann.adapterdelegates4.sample.model.DisplayableItem
 class MainListAdapter(activity: Activity) : ListDelegationAdapter<List<DisplayableItem>>(
     AdvertisementAdapterDelegate(activity),
     cat2AdapterDelegate(),
-    DogAdapterDelegate(activity),
+//    DogAdapterDelegate(activity),
     GeckoAdapterDelegate(activity),
     SnakeListItemAdapterDelegate(activity)
-)
\ No newline at end of file
+)
```

which will result in the following message change:

```diff
-No AdapterDelegate added that matches at position=1 in data source
+No AdapterDelegate added that matches item=Chinook com.hannesdorfmann.adapterdelegates4.sample.model.Dog@b3c8846 at position=1 in data source
```

